### PR TITLE
Add registrations link and disable snowfall effects

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -40,7 +40,7 @@ canvas {
 }
 
 .snow-section {
-	z-index: -25;
+	/*z-index: -25;*/
 }
 
 .logo img {

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 
         <nav id="site-nav" class="navbar navbar-fixed-top navbar-custom">
             <div class="navbar-header">
-    
+
                 <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-items"
                         aria-expanded="false">
                     <span class="sr-only">Toggle navigation</span>
@@ -62,23 +62,23 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-    
+
             </div><!-- /.navbar-header -->
-    
+
             <div class="collapse navbar-collapse" id="navbar-items">
                 <ul class="nav navbar-nav navbar-right">
-    
+
                     <!-- navigation menu -->
                     <li><a class="page-scroll" href="#about-section">About</a></li>
-                    <li><a class="page-scroll" href="#apply-section">Apply</a></li>
+                    <li><a class="page-scroll" href="#apply-section">Register</a></li>
                     <li><a class="page-scroll" href="#schedule-section">Schedule</a></li>
                     <li><a class="page-scroll" href="#sponsors-section">Sponsors</a></li>
                     <li><a class="page-scroll" href="#volunteer-section">Volunteer</a></li>
-    
+
                 </ul>
             </div>
         </nav>
-            
+
 
 
     </header>
@@ -96,7 +96,7 @@
                         <h2>Hosted by <a href="https://hackcu.org" style="color: inherit;">HackCU</a></h2><br>
                         <h3>Saturday December 2, 2017</h3>
                         <h3>Idea Forge, Boulder</h3>
-                        <center><a class="btn btn-lg btn-blank" role="button" disabled>Registrations Opening Soon</a></center>
+                        <center><a class="btn btn-lg btn-blank" role="button" href="#apply-section">Registrations Open!</a></center>
                     </div>
 
                     <div class="extra-space-l"></div>
@@ -219,9 +219,9 @@
                         <div class="row">
                             <div class="col-lg-12">
                                 <div class="page-header text-center">
-                                    <h2>Registrations for Local Hack Day will open soon!</h2>
+                                    <h2>Registrations are open!</h2>
                                     <div class="devider"></div>
-                                    <a class="btn btn-lg btn-blank" href="https://hackcu.org/" target="_blank" role="button">Sign up here to be notified</a>
+                                    <a class="btn btn-lg btn-blank" href="https://hackday.mlh.io/University%20of%20Colorado%20Boulder" target="_blank" role="button">Register now!</a>
                                 </div>
                             </div>
                         </div>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 
     <!-- Theme CSS -->
     <link rel="stylesheet" href="css/reset.css?v=1.0.3">
-    <link rel="stylesheet" href="css/style.css?v=1.0.4">
+    <link rel="stylesheet" href="css/style.css?v=1.0.5">
     <link rel="stylesheet" href="css/mobile.css?v=1.0.3">
     <link rel="stylesheet" href="css/form.css?v=1.0.3">
 


### PR DESCRIPTION
## Description
1. Local Hack Day registrations are open! Linked the website to appropriate websites
2. Snowfall effects (particularly the `z-index` property) disabled all links. So, I temporarily removed the effect until we fix it.

## Related Issues
Issues #22 and #27 are a result of the broken links due to `z-index`. Issue #32 is addressing the bigger question.

## Some questions
1. Did you read the contributing guidelines?
	Yes
2. Did you edit any CSS or JS file?
	Yes
3. If you answered yes, did you update the version number on `index.html`?
	Yes