### PR TITLE
Sponsor logos resizing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,3 +23,14 @@ Want to contribute to this repo? Great! We :heart: contributions. Just make sure
 	You will most probably end up making the third change.
 3. Test locally and make sure the website functions properly and you didn't break anything.
 4. Create a pull request with a descriptive title. Clearly document any changes you made. You should be able to explain why you made those changes.
+
+## Adding a new sponsor or partner logo?
+Follow the usual GitHub workflow outlined in the [first section](#new-feature-or-a-bug-fix?).
+Then follow these specific guidelines for resizing the logo.
+If you don't have access to professional tools like Photoshop, download [Gimp]. It is open source and has all the features you will need for resizing logos.
+1. Store the original logo in the `originals/` folder.
+2. Resize the logo to `600 x 400` px i.e., 600 px wide and 400 px tall.
+3. When resizing, turn on anti-aliasing to make sure the logo doesn't pixelate too much.
+4. Center the logo and make sure to leave some whitespace around the margins. If in doubt, add the logo to the website and view your changes on the browser to check if it is aligned properly and the logo is neither too large not too small compared to other logos.
+5. Finally, remove the background i.e., the background should be transparent and save as `PNG` file.
+If you're feeling lucky, try compressing the image outlined [here](https://github.com/HackCU/HackCU/pull/14).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Want to contribute to this repo? Great! We :heart: contributions. Just make sure
 ## Adding a new sponsor or partner logo?
 Follow the usual GitHub workflow outlined in the [first section](#new-feature-or-a-bug-fix?).
 Then follow these specific guidelines for resizing the logo.
-If you don't have access to professional tools like Photoshop, download [Gimp]. It is open source and has all the features you will need for resizing logos.
+If you don't have access to professional tools like Photoshop, download [GIMP](https://www.gimp.org/downloads/). It is free, open source, and has all the features you will need for resizing logos.
 1. Store the original logo in the `originals/` folder.
 2. Resize the logo to `600 x 400` px i.e., 600 px wide and 400 px tall.
 3. When resizing, turn on anti-aliasing to make sure the logo doesn't pixelate too much.

--- a/css/style.css
+++ b/css/style.css
@@ -1220,3 +1220,9 @@ td {
         padding-left: 2em;
 }
 /* ===== End tables ===== */
+
+/* Old sponsors */
+.old-sponsors img {
+    width: auto;
+    height: 100%;
+}

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 
     <!-- Theme CSS -->
     <link rel="stylesheet" href="css/reset.css?v=1.0.3">
-    <link rel="stylesheet" href="css/style.css?v=1.0.7">
+    <link rel="stylesheet" href="css/style.css?v=1.0.8">
     <link rel="stylesheet" href="css/mobile.css?v=1.0.3">
     <link rel="stylesheet" href="css/form.css?v=1.0.3">
 
@@ -378,117 +378,107 @@
                 <div class="extra-space-xxl"></div>
                 <div class="container">
                     <div class="page-header text-center">
-                        <h2>Our Past Sponsors</h2>
+                        <h3>Our Past Sponsors and Partners</h3>
                         <div class="devider"></div>
                         <div class="row">
-                            <div class="col-lg-6">
+                            <div class="col-md-2 old-sponsors" style="height:100px;">
                                 <a href="https://logrhythm.com/" target="_blank">
                                     <img src="img/sponsors/logrhythm.png">
                                 </a>
                             </div>
-                            <div class="col-lg-6">
+                            <div class="col-md-2 old-sponsors" style="height:80px;">
+                                <br>
                                 <a href="http://www.zayo.com/" target="_blank">
                                     <img src="img/sponsors/zayo.png">
                                 </a>
                             </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-lg-4">
+                            <div class="col-md-2 old-sponsors" style="height:100px;">
                                 <a href="https://www.travelport.com/" target="_blank">
                                     <img src="img/sponsors/travelport.png">
                                 </a>
                             </div>
-                            <div class="col-lg-4">
+                            <div class="col-md-2 old-sponsors" style="height:100px;">
                                 <a href="http://www.keysight.com/" target="_blank">
                                     <img src="img/sponsors/keysight.png">
                                 </a>
                             </div>
-                            <div class="col-lg-4">
+                            <div class="col-md-2 old-sponsors" style="height:90px;">
                                 <a href="https://twitter.com/" target="_blank">
                                  <img src="img/sponsors/twitter.png">
-                             </a>
-                         </div>
-                     </div>
-                     <div class="row">
-                        <div class="col-lg-12">
-                            <a href="http://www.ca.com/us.html" target="_blank">
-                                <img src="img/sponsors/catechnologies.png">
-                            </a>
+                                </a>
+                            </div>
+                            <div class="col-md-2 old-sponsors" style="height:70px;">
+                                <br>
+                                <a href="http://www.ca.com/us.html" target="_blank">
+                                    <img src="img/sponsors/catechnologies.png">
+                                </a>
+                            </div>
                         </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-lg-4">
-                            <a href="https://www.flytedesk.com/" target="_blank">
-                                <img src="img/sponsors/flytedesk.png">
-                            </a>
+                        <div class="row">
+                            <div class="col-md-2 old-sponsors" style="height: 100px;">
+                                <a href="https://www.flytedesk.com/" target="_blank">
+                                    <img src="img/sponsors/flytedesk.png">
+                                </a>
+                            </div>
+                            <div class="col-md-2 old-sponsors" style="height: 100px;">
+                                <a href="https://www.wowza.com/" target="_blank">
+                                    <img src="img/sponsors/wowza.png">
+                                </a>
+                            </div>
+                            <div class="col-md-2 old-sponsors" style="height: 100px;">
+                                <a href="https://www.sparkfun.com/" target="_blank">
+                                    <img src="img/sponsors/sparkfun.png">
+                                </a>
+                            </div>
+                            <div class="col-md-2 old-sponsors" style="height: 100px;">
+                                <a href="http://sparkboulder.com/" target="_blank">
+                                    <img src="img/partners/spark.png">
+                                </a>
+                            </div>
+                            <div class="col-md-2 old-sponsors" style="height: 100px;">
+                                <a href="https://mlh.io/" target="_blank">
+                                    <img src="img/partners/mlh-logo.png">
+                                </a>
+                            </div>
+                            <div class="col-md-2 old-sponsors" style="height: 100px;">
+                                <a href="http://www.colorado.edu/business/" target="_blank">
+                                    <img src="img/partners/leeds.png">
+                                </a>
+                            </div>
                         </div>
-                        <div class="col-lg-4">
-                            <a href="https://www.wowza.com/" target="_blank">
-                                <img src="img/sponsors/wowza.png">
-                            </a>
-                        </div>
-                        <div class="col-lg-4">
-                            <a href="https://www.sparkfun.com/" target="_blank">
-                                <img src="img/sponsors/sparkfun.png">
-                            </a>
+                        <div class="row">
+                            <div class="col-md-1 old-sponsors" style="height: 100px;"></div>
+                            <div class="col-md-2 old-sponsors" style="height: 100px;">
+                                <a href="http://atlas.colorado.edu/" target="_blank">
+                                    <img src="img/partners/atlas.png">
+                                </a>
+                            </div>
+                            <div class="col-md-2 old-sponsors" style="height: 110px;">
+                                <a href="http://www.colorado.edu/engineering/home-page" target="_blank">
+                                    <img src="img/partners/engineering.png">
+                                </a>
+                            </div>
+                            <div class="col-md-2 old-sponsors" style="height: 100px;">
+                                <a href="http://www.kindsnacks.com/" target="_blank">
+                                    <img src="img/partners/kind.png">
+                                </a>
+                            </div>
+                            <div class="col-md-2 old-sponsors" style="height: 100px;">
+                                <a href="https://www.soylent.com/" target="_blank">
+                                    <img src="img/partners/soylent-logo.png">
+                                </a>
+                            </div>
+                            <div class="col-md-2 old-sponsors" style="height: 100px;">
+                                <a href="http://lunchboxelectronics.com/" target="_blank">
+                                    <img src="img/partners/lunchbox-electronics.png">
+                                </a>
+                            </div>
+                            <div class="col-md-1 old-sponsors" style="height: 100px;"></div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-        <div class="page-header-wrapper">
-            <div class="container" id="partners-section">
-                <div class="page-header text-center">
-                    <h2>Our Past Partners</h2>
-                    <div class="devider"></div>
-                    <div class="row">
-                        <div class="col-lg-6 mar">
-                            <a href="http://sparkboulder.com/" target="_blank">
-                                <img src="img/partners/spark.png">
-                            </a>
-                        </div>
-                        <div class="col-lg-6 mar">
-                            <a href="https://mlh.io/" target="_blank">
-                                <img src="img/partners/mlh-logo.png">
-                            </a>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-lg-4 mar">
-                            <a href="http://www.colorado.edu/business/" target="_blank">
-                                <img src="img/partners/leeds.png">
-                            </a>
-                        </div>
-                        <div class="col-lg-4 mar">
-                            <a href="http://atlas.colorado.edu/" target="_blank">
-                                <img src="img/partners/atlas.png">
-                            </a>
-                        </div>
-                        <div class="col-lg-4 mar">
-                            <a href="http://www.colorado.edu/engineering/home-page" target="_blank">
-                                <img src="img/partners/engineering.png">
-                            </a>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-lg-4 mar">
-                            <a href="http://www.kindsnacks.com/" target="_blank">
-                                <img src="img/partners/kind.png">
-                            </a>
-                        </div>
-                        <div class="col-lg-4 mar">
-                            <a href="https://www.soylent.com/" target="_blank">
-                                <img src="img/partners/soylent-logo.png">
-                            </a>
-                        </div>
-                        <div class="col-lg-4 mar">
-                            <a href="http://lunchboxelectronics.com/" target="_blank">
-                                <img src="img/partners/lunchbox-electronics.png">
-                            </a>
-                        </div>
-                    </div>
-                </div>
-            </div>
         </section>
 
         <!-- VOLUNTEER/MENTOR SECTION -->

--- a/index.html
+++ b/index.html
@@ -50,61 +50,55 @@
 </head>
 <body data-spy="scroll" data-target="#main-navbar">
 
-    <header id="header" class="header-main">
+<header id="header" class="header-main">
+    <nav id="site-nav" class="navbar navbar-fixed-top navbar-custom">
+        <div class="navbar-header">
 
-        <nav id="site-nav" class="navbar navbar-fixed-top navbar-custom">
-            <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-items"
+                    aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
 
-                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-items"
-                        aria-expanded="false">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </button>
+        </div><!-- /.navbar-header -->
 
-            </div><!-- /.navbar-header -->
+        <div class="collapse navbar-collapse" id="navbar-items">
+            <ul class="nav navbar-nav navbar-right">
 
-            <div class="collapse navbar-collapse" id="navbar-items">
-                <ul class="nav navbar-nav navbar-right">
+                <!-- navigation menu -->
+                <li><a class="page-scroll" href="#about-section">About</a></li>
+                <li><a class="page-scroll" href="#apply-section">Register</a></li>
+                <li><a class="page-scroll" href="#schedule-section">Schedule</a></li>
+                <li><a class="page-scroll" href="#sponsors-section">Sponsors</a></li>
+                <li><a class="page-scroll" href="#volunteer-section">Volunteer</a></li>
 
-                    <!-- navigation menu -->
-                    <li><a class="page-scroll" href="#about-section">About</a></li>
-                    <li><a class="page-scroll" href="#apply-section">Register</a></li>
-                    <li><a class="page-scroll" href="#schedule-section">Schedule</a></li>
-                    <li><a class="page-scroll" href="#sponsors-section">Sponsors</a></li>
-                    <li><a class="page-scroll" href="#volunteer-section">Volunteer</a></li>
+            </ul>
+        </div>
+    </nav>
+</header>
 
-                </ul>
-            </div>
-        </nav>
+<section id="text-carousel-intro-section" class="snow-section">
+    <div class="header text-white parallax" >
+        <div class="cover-flatirons"></div>
+        <div class="container">
+            <div class="caption text-center">
 
-
-
-    </header>
-
-    <section id="text-carousel-intro-section" class="snow-section">
-        <div class="header text-white parallax" >
-            <div class="cover-flatirons"></div>
-
-            <div class="container">
-                <div class="caption text-center">
-
-                    <div id="logo" class="logo">
-                        <br>
-                        <img src="img/localhackday.svg" alt="Local Hack Day Logo">
-                        <h2>Hosted by <a href="https://hackcu.org" style="color: inherit;">HackCU</a></h2><br>
-                        <h3>Saturday December 2, 2017</h3>
-                        <h3>Idea Forge, Boulder</h3>
-                        <center><a class="btn btn-lg btn-blank" role="button" href="https://hackday.mlh.io/University%20of%20Colorado%20Boulder">Registrations Open!</a></center>
-                    </div>
-
-                    <div class="extra-space-l"></div>
+                <div id="logo" class="logo">
+                    <br>
+                    <img src="img/localhackday.svg" alt="Local Hack Day Logo">
+                    <h2>Hosted by <a href="https://hackcu.org" style="color: inherit;">HackCU</a></h2><br>
+                    <h3>Saturday December 2, 2017</h3>
+                    <h3>Idea Forge, Boulder</h3>
+                    <center><a class="btn btn-lg btn-blank" role="button" href="https://hackday.mlh.io/University%20of%20Colorado%20Boulder">Registrations Open!</a></center>
                 </div>
+
+                <div class="extra-space-l"></div>
             </div>
         </div>
-    </section>
-
+    </div>
+</section>
 
 <section id="about-section" class="page bg-style1 shadow">
     <div class="page-header-wrapper">
@@ -182,372 +176,372 @@
                     <div class="rotate-box-info">
                         <h4>What about teams?</h4>
                         <p>You can have a maximum of 4 members on your team. There will time before the hacking begins where we will help you to find a team.</p>
-                        </div>
                     </div>
+                </div>
 
-                    <div class="col-md-3 col-sm-6">
-                        <span class="rotate-box-icon"><i class=""></i></span>
-                        <div class="rotate-box-info">
-                            <h4>How can I help?</h4>
-                            <p>We always need volunteers and mentors! <a href="mailto:contact@hackcu.org">Email
-                            us</a> for more info.</p>
-                        </div>
+                <div class="col-md-3 col-sm-6">
+                    <span class="rotate-box-icon"><i class=""></i></span>
+                    <div class="rotate-box-info">
+                        <h4>How can I help?</h4>
+                        <p>We always need volunteers and mentors! <a href="mailto:contact@hackcu.org">Email
+                        us</a> for more info.</p>
                     </div>
+                </div>
 
-                    <div class="col-md-3 col-sm-6">
-                        <span class="rotate-box-icon"><i class=""></i></span>
-                        <div class="rotate-box-info">
-                            <h4>Need to contact us?</h4>
-                            <p>Shoot us a message on <a href="https://www.facebook.com/hackcu"> Facebook</a> or <a
-                                href="https://twitter.com/HackCU">Twitter</a>, or <a
-                                href="mailto:contact@hackcu.org">Email us</a>!</p>
-                            </div>
-                        </div>
+                <div class="col-md-3 col-sm-6">
+                    <span class="rotate-box-icon"><i class=""></i></span>
+                    <div class="rotate-box-info">
+                        <h4>Need to contact us?</h4>
+                        <p>Shoot us a message on <a href="https://www.facebook.com/hackcu"> Facebook</a> or <a
+                            href="https://twitter.com/HackCU">Twitter</a>, or <a
+                            href="mailto:contact@hackcu.org">Email us</a>!</p>
                     </div>
                 </div>
             </div>
-            <div class="extra-space-l"></div>
-        </section>
+        </div>
+    </div>
+    <div class="extra-space-l"></div>
+</section>
 
 
-        <!-- APPLY SECTION -->
-        <section id="apply-section" class="snow-section">
-            <div class="testimonial text-white parallax">
-                <div class="cover-small"></div>
-                <div class="page-header-wrapper">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-lg-12">
-                                <div class="page-header text-center">
-                                    <h2>Registrations are open!</h2>
-                                    <div class="devider"></div>
-                                    <a class="btn btn-lg btn-blank" href="https://hackday.mlh.io/University%20of%20Colorado%20Boulder" target="_blank" role="button">Register now!</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-
-        <!-- LOCAL HACK DAY SCHEDULE -->
-        <section id="schedule-section" class="page bg-style1 shadow">
-            <div class="page-header-wrapper">
-                <div class="container">
-                    <div class="page-header text-center">
-                        <h2>Event Schedule</h2>
-                        <div class="devider"></div>
-                        <p class="subtitle">Subject to change.</p>
-                    </div>
-                </div>
-            </div>
+<!-- APPLY SECTION -->
+<section id="apply-section" class="snow-section">
+    <div class="testimonial text-white parallax">
+        <div class="cover-small"></div>
+        <div class="page-header-wrapper">
             <div class="container">
-                <div class="col-md-6">
-                    <table class="table lead table-hover text-center">
-                        <thead>
-                            <tr>
-                                <th class="text-center">Time</th>
-                                <th class="text-center">Event</th>
-                            </tr>
-                        </thead>
-                        <tr>
-                            <td>08:00 am</td>
-                            <td>Arrival and Check-in</td>
-                        </tr>
-                        <tr>
-                            <td>08:30 am</td>
-                            <td>Opening Ceremonies</td>
-                        </tr>
-                        <tr>
-                            <td>08:45 am</td>
-                            <td>Team Formation</td>
-                        </tr>
-                        <tr>
-                            <td>09:00 am</td>
-                            <td>Hacking Begins!</td>
-                        </tr>
-                        <tr>
-                            <td>09:30 am</td>
-                            <td>Breakfast</td>
-                        </tr>
-                    </table>
-                </div>
-                <div class="col-md-6">
-                    <table class="table lead table-hover text-center">
-                        <thead>
-                            <tr>
-                                <th class="text-center">Time</th>
-                                <th class="text-center">Event</th>
-                            </tr>
-                        </thead>
-                        <tr>
-                            <td>12:30 pm</td>
-                            <td>Lunch</td>
-                        </tr>
-                        <tr>
-                            <td>06:00 pm</td>
-                            <td>Dinner</td>
-                        </tr>
-                        <tr>
-                            <td>08:00 pm</td>
-                            <td>Dessert Served</td>
-                        </tr>
-                        <tr>
-                            <td>09:00 pm</td>
-                            <td>Hacking Ends!</td>
-                        </tr>
-                        <tr>
-                            <td>09:15 pm</td>
-                            <td>Closing Ceremonies</td>
-                        </tr>
-                    </table>
-                </div>
-            </div>
-            <div class="extra-space-l"></div>
-        </section>
-
-        <!-- COUNTER SECTION -->
-        <section id="counter-section" class="snow-section">
-            <div id="counter-up-trigger" class="counter-up text-white parallax">
-                <div class="cover-flatirons"></div>
-                <div class="page-header-wrapper">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-lg-12">
-                                <div class="page-header text-center">
-                                    <h2>Our Goals for Local Hack Day 2017</h2>
-                                    <div class="devider"></div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="container">
-                    <div class="row">
-                        <div class="fact text-center col-md-3 col-sm-6">
-                            <div class="fact-inner">
-                                <i class="fa fa-users fa-3x"></i>
-                                <div class="extra-space-l"></div>
-                                <span class="counter">200</span>
-                                <p class="lead">Participants</p>
-                            </div>
-                        </div>
-                        <div class="fact text-center col-md-3 col-sm-6">
-                            <div class="fact-inner">
-                                <i class="fa fa-gears fa-3x"></i>
-                                <div class="extra-space-l"></div>
-                                <span class="counter">50</span>
-                                <p class="lead">Awesome Projects</p>
-                            </div>
-                        </div>
-                        <div class="fact text-center col-md-3 col-sm-6">
-                            <div class="fact-inner">
-                                <i class="fa fa-coffee fa-3x"></i>
-                                <div class="extra-space-l"></div>
-                                <span class="counter">500</span>
-                                <p class="lead">Energy Drinks</p>
-                            </div>
-                        </div>
-                        <div class="fact last text-center col-md-3 col-sm-6">
-                            <div class="fact-inner">
-                                <i class="fa fa-clock-o fa-3x"></i>
-                                <div class="extra-space-l"></div>
-                                <span class="counter">12</span>
-                                <p class="lead">Hours of Hacking</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-
-        <!-- SPONSORS SECTION -->
-        <section id="sponsors-section" class="shadow">
-            <div class="page-header-wrapper">
-                <div class="container">
-                    <div class="row">
-                        <div class="col-lg-12 text-center">
-                            <h4>Want to sponsor or partner with HackCU?</h4>
-                            <div class="extra-space-l"></div>
-                            <a class="btn btn-lg btn-blank btn-plain" href="mailto:sponsors@hackcu.org" role="button">Contact Us!</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="extra-space-xxl"></div>
-                <div class="container">
-                    <div class="page-header text-center">
-                        <h3>Our Past Sponsors and Partners</h3>
-                        <div class="devider"></div>
-                        <div class="row">
-                            <div class="col-md-2 old-sponsors" style="height:100px;">
-                                <a href="https://logrhythm.com/" target="_blank">
-                                    <img src="img/sponsors/logrhythm.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height:80px;">
-                                <br>
-                                <a href="http://www.zayo.com/" target="_blank">
-                                    <img src="img/sponsors/zayo.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height:100px;">
-                                <a href="https://www.travelport.com/" target="_blank">
-                                    <img src="img/sponsors/travelport.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height:100px;">
-                                <a href="http://www.keysight.com/" target="_blank">
-                                    <img src="img/sponsors/keysight.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height:90px;">
-                                <a href="https://twitter.com/" target="_blank">
-                                 <img src="img/sponsors/twitter.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height:70px;">
-                                <br>
-                                <a href="http://www.ca.com/us.html" target="_blank">
-                                    <img src="img/sponsors/catechnologies.png">
-                                </a>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-2 old-sponsors" style="height: 100px;">
-                                <a href="https://www.flytedesk.com/" target="_blank">
-                                    <img src="img/sponsors/flytedesk.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height: 100px;">
-                                <a href="https://www.wowza.com/" target="_blank">
-                                    <img src="img/sponsors/wowza.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height: 100px;">
-                                <a href="https://www.sparkfun.com/" target="_blank">
-                                    <img src="img/sponsors/sparkfun.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height: 100px;">
-                                <a href="http://sparkboulder.com/" target="_blank">
-                                    <img src="img/partners/spark.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height: 100px;">
-                                <a href="https://mlh.io/" target="_blank">
-                                    <img src="img/partners/mlh-logo.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height: 100px;">
-                                <a href="http://www.colorado.edu/business/" target="_blank">
-                                    <img src="img/partners/leeds.png">
-                                </a>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-1 old-sponsors" style="height: 100px;"></div>
-                            <div class="col-md-2 old-sponsors" style="height: 100px;">
-                                <a href="http://atlas.colorado.edu/" target="_blank">
-                                    <img src="img/partners/atlas.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height: 110px;">
-                                <a href="http://www.colorado.edu/engineering/home-page" target="_blank">
-                                    <img src="img/partners/engineering.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height: 100px;">
-                                <a href="http://www.kindsnacks.com/" target="_blank">
-                                    <img src="img/partners/kind.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height: 100px;">
-                                <a href="https://www.soylent.com/" target="_blank">
-                                    <img src="img/partners/soylent-logo.png">
-                                </a>
-                            </div>
-                            <div class="col-md-2 old-sponsors" style="height: 100px;">
-                                <a href="http://lunchboxelectronics.com/" target="_blank">
-                                    <img src="img/partners/lunchbox-electronics.png">
-                                </a>
-                            </div>
-                            <div class="col-md-1 old-sponsors" style="height: 100px;"></div>
+                <div class="row">
+                    <div class="col-lg-12">
+                        <div class="page-header text-center">
+                            <h2>Registrations are open!</h2>
+                            <div class="devider"></div>
+                            <a class="btn btn-lg btn-blank" href="https://hackday.mlh.io/University%20of%20Colorado%20Boulder" target="_blank" role="button">Register now!</a>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-        </section>
+    </div>
+</section>
 
-        <!-- VOLUNTEER/MENTOR SECTION -->
-        <section id="volunteer-section" class="snow-section">
-            <div id="" class="testimonial text-white parallax">
-                <div class="cover-small"></div>
-                <div class="page-header-wrapper">
+
+<!-- LOCAL HACK DAY SCHEDULE -->
+<section id="schedule-section" class="page bg-style1 shadow">
+    <div class="page-header-wrapper">
+        <div class="container">
+            <div class="page-header text-center">
+                <h2>Event Schedule</h2>
+                <div class="devider"></div>
+                <p class="subtitle">Subject to change.</p>
+            </div>
+        </div>
+    </div>
+    <div class="container">
+        <div class="col-md-6">
+            <table class="table lead table-hover text-center">
+                <thead>
+                    <tr>
+                        <th class="text-center">Time</th>
+                        <th class="text-center">Event</th>
+                    </tr>
+                </thead>
+                <tr>
+                    <td>08:00 am</td>
+                    <td>Arrival and Check-in</td>
+                </tr>
+                <tr>
+                    <td>08:30 am</td>
+                    <td>Opening Ceremonies</td>
+                </tr>
+                <tr>
+                    <td>08:45 am</td>
+                    <td>Team Formation</td>
+                </tr>
+                <tr>
+                    <td>09:00 am</td>
+                    <td>Hacking Begins!</td>
+                </tr>
+                <tr>
+                    <td>09:30 am</td>
+                    <td>Breakfast</td>
+                </tr>
+            </table>
+        </div>
+        <div class="col-md-6">
+            <table class="table lead table-hover text-center">
+                <thead>
+                    <tr>
+                        <th class="text-center">Time</th>
+                        <th class="text-center">Event</th>
+                    </tr>
+                </thead>
+                <tr>
+                    <td>12:30 pm</td>
+                    <td>Lunch</td>
+                </tr>
+                <tr>
+                    <td>06:00 pm</td>
+                    <td>Dinner</td>
+                </tr>
+                <tr>
+                    <td>08:00 pm</td>
+                    <td>Dessert Served</td>
+                </tr>
+                <tr>
+                    <td>09:00 pm</td>
+                    <td>Hacking Ends!</td>
+                </tr>
+                <tr>
+                    <td>09:15 pm</td>
+                    <td>Closing Ceremonies</td>
+                </tr>
+            </table>
+        </div>
+    </div>
+    <div class="extra-space-l"></div>
+</section>
+
+<!-- COUNTER SECTION -->
+<section id="counter-section" class="snow-section">
+    <div id="counter-up-trigger" class="counter-up text-white parallax">
+        <div class="cover-flatirons"></div>
+        <div class="page-header-wrapper">
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-12">
+                        <div class="page-header text-center">
+                            <h2>Our Goals for Local Hack Day 2017</h2>
+                            <div class="devider"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="container">
+            <div class="row">
+                <div class="fact text-center col-md-3 col-sm-6">
+                    <div class="fact-inner">
+                        <i class="fa fa-users fa-3x"></i>
+                        <div class="extra-space-l"></div>
+                        <span class="counter">200</span>
+                        <p class="lead">Participants</p>
+                    </div>
+                </div>
+                <div class="fact text-center col-md-3 col-sm-6">
+                    <div class="fact-inner">
+                        <i class="fa fa-gears fa-3x"></i>
+                        <div class="extra-space-l"></div>
+                        <span class="counter">50</span>
+                        <p class="lead">Awesome Projects</p>
+                    </div>
+                </div>
+                <div class="fact text-center col-md-3 col-sm-6">
+                    <div class="fact-inner">
+                        <i class="fa fa-coffee fa-3x"></i>
+                        <div class="extra-space-l"></div>
+                        <span class="counter">500</span>
+                        <p class="lead">Energy Drinks</p>
+                    </div>
+                </div>
+                <div class="fact last text-center col-md-3 col-sm-6">
+                    <div class="fact-inner">
+                        <i class="fa fa-clock-o fa-3x"></i>
+                        <div class="extra-space-l"></div>
+                        <span class="counter">12</span>
+                        <p class="lead">Hours of Hacking</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+
+<!-- SPONSORS SECTION -->
+<section id="sponsors-section" class="shadow">
+    <div class="page-header-wrapper">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h4>Want to sponsor or partner with HackCU?</h4>
+                    <div class="extra-space-l"></div>
+                    <a class="btn btn-lg btn-blank btn-plain" href="mailto:sponsors@hackcu.org" role="button">Contact Us!</a>
+                </div>
+            </div>
+        </div>
+        <div class="extra-space-xxl"></div>
+        <div class="container">
+            <div class="page-header text-center">
+                <h3>Our Past Sponsors and Partners</h3>
+                <div class="devider"></div>
+                <div class="row">
+                    <div class="col-md-2 old-sponsors" style="height:100px;">
+                        <a href="https://logrhythm.com/" target="_blank">
+                            <img src="img/sponsors/logrhythm.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height:80px;">
+                        <br>
+                        <a href="http://www.zayo.com/" target="_blank">
+                            <img src="img/sponsors/zayo.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height:100px;">
+                        <a href="https://www.travelport.com/" target="_blank">
+                            <img src="img/sponsors/travelport.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height:100px;">
+                        <a href="http://www.keysight.com/" target="_blank">
+                            <img src="img/sponsors/keysight.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height:90px;">
+                        <a href="https://twitter.com/" target="_blank">
+                         <img src="img/sponsors/twitter.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height:70px;">
+                        <br>
+                        <a href="http://www.ca.com/us.html" target="_blank">
+                            <img src="img/sponsors/catechnologies.png">
+                        </a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-2 old-sponsors" style="height: 100px;">
+                        <a href="https://www.flytedesk.com/" target="_blank">
+                            <img src="img/sponsors/flytedesk.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height: 100px;">
+                        <a href="https://www.wowza.com/" target="_blank">
+                            <img src="img/sponsors/wowza.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height: 100px;">
+                        <a href="https://www.sparkfun.com/" target="_blank">
+                            <img src="img/sponsors/sparkfun.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height: 100px;">
+                        <a href="http://sparkboulder.com/" target="_blank">
+                            <img src="img/partners/spark.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height: 100px;">
+                        <a href="https://mlh.io/" target="_blank">
+                            <img src="img/partners/mlh-logo.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height: 100px;">
+                        <a href="http://www.colorado.edu/business/" target="_blank">
+                            <img src="img/partners/leeds.png">
+                        </a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-1 old-sponsors" style="height: 100px;"></div>
+                    <div class="col-md-2 old-sponsors" style="height: 100px;">
+                        <a href="http://atlas.colorado.edu/" target="_blank">
+                            <img src="img/partners/atlas.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height: 110px;">
+                        <a href="http://www.colorado.edu/engineering/home-page" target="_blank">
+                            <img src="img/partners/engineering.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height: 100px;">
+                        <a href="http://www.kindsnacks.com/" target="_blank">
+                            <img src="img/partners/kind.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height: 100px;">
+                        <a href="https://www.soylent.com/" target="_blank">
+                            <img src="img/partners/soylent-logo.png">
+                        </a>
+                    </div>
+                    <div class="col-md-2 old-sponsors" style="height: 100px;">
+                        <a href="http://lunchboxelectronics.com/" target="_blank">
+                            <img src="img/partners/lunchbox-electronics.png">
+                        </a>
+                    </div>
+                    <div class="col-md-1 old-sponsors" style="height: 100px;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</section>
+
+<!-- VOLUNTEER/MENTOR SECTION -->
+<section id="volunteer-section" class="snow-section">
+    <div id="" class="testimonial text-white parallax">
+        <div class="cover-small"></div>
+        <div class="page-header-wrapper">
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-12">
+                        <div class="page-header text-center">
+                            <h2>Volunteer or Mentor for Local Hack Day</h2>
+                            <div class="devider"></div>
+                            <div class="extra-space-m"></div>
+                            <p class="subtitle" style="font-size: large;">Email us at Contact@HackCU.org to volunteer or mentor!</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+
+<!-- Begin footer -->
+<footer class="text-off-white shadow" >
+    <div class="footer-top">
+        <div class="container">
+            <div class="row">
+                <div class="col-sm-4 col-md-4">
                     <div class="container">
-                        <div class="row">
-                            <div class="col-lg-12">
-                                <div class="page-header text-center">
-                                    <h2>Volunteer or Mentor for Local Hack Day</h2>
-                                    <div class="devider"></div>
-                                    <div class="extra-space-m"></div>
-                                    <p class="subtitle" style="font-size: large;">Email us at Contact@HackCU.org to volunteer or mentor!</p>
-                                </div>
-                            </div>
-                        </div>
+                        <ul class="imp-links">
+                            <li><a target="_blank" href="https://hackcu.org">Sign up to stay updated</a></li>
+                            <li><a target="_blank" href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf">Code of Conduct</a></li>
+                            <li><a target="_blank" href="mailto:contact@hackcu.org">Email Us</a></li>
+                        </ul>
                     </div>
                 </div>
-            </div>
-        </section>
-
-
-        <!-- Begin footer -->
-        <footer class="text-off-white shadow" >
-            <div class="footer-top">
-                <div class="container">
-                    <div class="row">
-                        <div class="col-sm-4 col-md-4">
-                            <div class="container">
-                                <ul class="imp-links">
-                                    <li><a target="_blank" href="https://hackcu.org">Sign up to stay updated</a></li>
-                                    <li><a target="_blank" href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf">Code of Conduct</a></li>
-                                    <li><a target="_blank" href="mailto:contact@hackcu.org">Email Us</a></li>
-                                </ul>
-                            </div>
-                        </div>
-                        <div class="col-sm-4 col-md-4">
-                            <ul class="social-list blue">
-                                <li>
-                                    <a target="_blank" href="https://www.facebook.com/hackcu/" class="rotate-box-1 square-icon text-center">
-                                        <span class="rotate-box-icon"><i class="fa fa-facebook"></i></span>
-                                    </a>
-                                </li>
-                                <li>
-                                    <a target="_blank" href="https://twitter.com/HackCU" class="rotate-box-1 square-icon text-center">
-                                        <span class="rotate-box-icon"><i class="fa fa-twitter"></i></span>
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                        <div class="col-sm-4 col-md-4 text-right">
-                            <ul class="imp-links">
-                                <li>
-                                    <a target="_blank" href="https://2017.hackcu.org/">HackCU 2017</a>&nbsp;&middot;&nbsp;
-                                    <a target="_blank" href="https://hackcu3.devpost.com/submissions">Winners</a>
-                                </li>
-                                <li>
-                                    <a target="_blank" href="https://2016.hackcu.org/">HackCU 2016</a>&nbsp;&middot;&nbsp;
-                                    <a target="_blank" href="https://hackcu.devpost.com/submissions">Winners</a>
-                                </li>
-                                <li><a target="_blank" href="http://startups2students.org/">Startups2Students</a></li>
-                            </ul>
-                        </div>
-                    </div>
+                <div class="col-sm-4 col-md-4">
+                    <ul class="social-list blue">
+                        <li>
+                            <a target="_blank" href="https://www.facebook.com/hackcu/" class="rotate-box-1 square-icon text-center">
+                                <span class="rotate-box-icon"><i class="fa fa-facebook"></i></span>
+                            </a>
+                        </li>
+                        <li>
+                            <a target="_blank" href="https://twitter.com/HackCU" class="rotate-box-1 square-icon text-center">
+                                <span class="rotate-box-icon"><i class="fa fa-twitter"></i></span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="col-sm-4 col-md-4 text-right">
+                    <ul class="imp-links">
+                        <li>
+                            <a target="_blank" href="https://2017.hackcu.org/">HackCU 2017</a>&nbsp;&middot;&nbsp;
+                            <a target="_blank" href="https://hackcu3.devpost.com/submissions">Winners</a>
+                        </li>
+                        <li>
+                            <a target="_blank" href="https://2016.hackcu.org/">HackCU 2016</a>&nbsp;&middot;&nbsp;
+                            <a target="_blank" href="https://hackcu.devpost.com/submissions">Winners</a>
+                        </li>
+                        <li><a target="_blank" href="http://startups2students.org/">Startups2Students</a></li>
+                    </ul>
                 </div>
             </div>
-        </footer>
+        </div>
+    </div>
+</footer>
 <!-- End footer -->
 <!-- All JavaScript includes  -->
 


### PR DESCRIPTION
## Description
A few things:
1. Resized old sponsors and partners logos and put them in single section. Did this because, earlier the old sponsors section took too much space and any causal browser could mistake them for current sponsors if they didn't read the title. This is what it looks like right now:<br>
![image](https://user-images.githubusercontent.com/16863215/32338861-973dd23a-bfbb-11e7-8fd6-0dab6e47927f.png)

2. Added documentation for adding new logos in the future. Closes #12 
<br>**Bonus** Fixed some wild indentation and missing `</div>` tags.

## Related Issues
Closes #12 

## Some questions
1. Did you read the contributing guidelines?
	Yes
2. Did you edit any CSS or JS file?
	Yes
3. If you answered yes, did you update the version number on `index.html`?
	Yes

## Additional Notes
Can we squash and merge this?
